### PR TITLE
added elasticsearch support issue-#606 (#25)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>mongo-spark-connector_${scala.binary.version}</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-hadoop</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/SourceIdentifier.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/SourceIdentifier.scala
@@ -46,5 +46,8 @@ object SourceIdentifier {
   def forMongoDB(connectionUrl: String, database: String, collection: String): SourceIdentifier =
     SourceIdentifier(Some("mongodb"), SourceUri.forMongoDB(connectionUrl, database, collection))
 
+  def forElasticSearch(server: String, indexDocType: String): SourceIdentifier =
+    SourceIdentifier(Some("elasticsearch"), SourceUri.forElastiSearch(server, indexDocType))
+
 
 }

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/SourceUri.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/SourceUri.scala
@@ -28,6 +28,8 @@ object SourceUri {
 
   def forMongoDB(connectionUrl: String, database: String, collection: String): String = s"$connectionUrl/$database.$collection"
 
+  def forElastiSearch(server: String, indexDocType: String): String = s"elasticsearch://$server/$indexDocType"
+
   def forTable(tableIdentifier: TableIdentifier)
     (session: SparkSession): String = {
     val catalog = session.catalog

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteCommandExtractor.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteCommandExtractor.scala
@@ -48,18 +48,17 @@ class WriteCommandExtractor(pathQualifier: PathQualifier, session: SparkSession)
             val tableName = cmd.options("dbtable")
             WriteCommand(cmd.nodeName, SourceIdentifier.forJDBC(jdbcConnectionString, tableName), cmd.mode, cmd.query)
 
-          case Some(sourceType) if sourceType == "cassandra" || sourceType.isInstanceOf[org.apache.spark.sql.cassandra.DefaultSource] =>
-            asCassandarWriteCommand(cmd)
-
-          case Some(sourceType) if sourceType == "mongo" || sourceType.isInstanceOf[com.mongodb.spark.sql.DefaultSource] =>
-            asMongoDBWriteCommand(cmd)
-
           case Some(ExcelSourceExtractor(_)) => asExcelWriteCommand(cmd)
           case Some("com.crealytics.spark.excel") => asExcelWriteCommand(cmd)
 
+          case Some(CassandraSourceExtractor(_)) => asCassandarWriteCommand(cmd)
           case Some("org.apache.spark.sql.cassandra") => asCassandarWriteCommand(cmd) //for spark 2.2
 
+          case Some(MongoDBSourceExtractor(_)) => asMongoDBWriteCommand(cmd)
           case Some("com.mongodb.spark.sql.DefaultSource") => asMongoDBWriteCommand(cmd) //for spark 2.2
+
+          case Some(ElasticSearchSourceExtractor(_)) => asElasticSearchWriteCommand(cmd)
+          case Some("es") => asElasticSearchWriteCommand(cmd) //for spark 2.2
 
           case _ =>
             val maybeFormat = maybeSourceType.map {
@@ -129,6 +128,12 @@ class WriteCommandExtractor(pathQualifier: PathQualifier, session: SparkSession)
     WriteCommand(cmd.nodeName, SourceIdentifier.forMongoDB(uri, database, collection), cmd.mode, cmd.query, cmd.options)
   }
 
+  private def asElasticSearchWriteCommand(cmd: SaveIntoDataSourceCommand) = {
+    val indexDocType = cmd.options("path")
+    val server = cmd.options("es.nodes")
+    WriteCommand(cmd.nodeName, SourceIdentifier.forElasticSearch(server, indexDocType), cmd.mode, cmd.query, cmd.options)
+  }
+
   private def asDirWriteCommand(name: String, storage: CatalogStorageFormat, provider: String, overwrite: Boolean, query: LogicalPlan) = {
     val uri = storage.locationUri.getOrElse(sys.error(s"Cannot determine the data source location: $storage"))
     val mode = if (overwrite) Overwrite else Append
@@ -170,7 +175,11 @@ object WriteCommandExtractor {
 
   private object ExcelSourceExtractor extends SafeTypeMatchingExtractor(classOf[DefaultSource])
 
-  private object CassandraSourceExtractor extends SafeTypeMatchingExtractor(classOf[DefaultSource])
+  private object CassandraSourceExtractor extends SafeTypeMatchingExtractor(classOf[org.apache.spark.sql.cassandra.DefaultSource])
+
+  private object MongoDBSourceExtractor extends SafeTypeMatchingExtractor(classOf[com.mongodb.spark.sql.DefaultSource])
+
+  private object ElasticSearchSourceExtractor extends SafeTypeMatchingExtractor(classOf[org.elasticsearch.spark.sql.DefaultSource15])
 
   private object DataSourceTypeExtractor extends AccessorMethodValueExtractor[AnyRef]("provider", "dataSource")
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -107,6 +107,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-hadoop</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.cassandraunit</groupId>
             <artifactId>cassandra-unit</artifactId>
             <version>2.1.9.2</version>
@@ -116,6 +121,12 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <version>1.47.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>pl.allegro.tech</groupId>
+            <artifactId>embedded-elasticsearch</artifactId>
+            <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/src/test/scala/za/co/absa/spline/ElasticSearchSpec.scala
+++ b/integration-tests/src/test/scala/za/co/absa/spline/ElasticSearchSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline
+
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import pl.allegro.tech.embeddedelasticsearch.{EmbeddedElastic, IndexSettings, PopularProperties}
+import za.co.absa.spline.test.fixture.SparkFixture
+import za.co.absa.spline.test.fixture.spline.SplineFixture
+import za.co.absa.commons.scalatest.ConditionalTestTags.ignoreIf
+import za.co.absa.commons.version.Version._
+
+class ElasticSearchSpec
+  extends AnyFlatSpec
+    with Matchers
+    with SparkFixture
+    with SplineFixture {
+
+  val sparkFormat = "es"
+  val index = "test"
+  val docType = "test"
+  val esNodes = "localhost"
+  val tcpPort = 9350
+  val clusterName = "my_cluster"
+  val options = Map("es.nodes" -> esNodes)
+
+  it should "support ES" taggedAs ignoreIf(semver"${util.Properties.versionNumberString}" >= semver"2.12.0") in {
+
+    val embeddedElastic = EmbeddedElastic.builder()
+      .withElasticVersion("6.6.0")
+      .withSetting(PopularProperties.TRANSPORT_TCP_PORT, tcpPort)
+      .withSetting(PopularProperties.CLUSTER_NAME, clusterName)
+      .withStartTimeout(5, TimeUnit.MINUTES)
+      .withIndex(index, IndexSettings.builder().build())
+      .build()
+    embeddedElastic.start()
+
+    withNewSparkSession(spark => {
+      withLineageTracking(spark)(lineageCaptor => {
+
+        val testData: DataFrame = {
+          val schema = StructType(StructField("id", IntegerType, nullable = false) :: StructField("name", StringType, nullable = false) :: Nil)
+          val rdd = spark.sparkContext.parallelize(Row(1014, "Warsaw") :: Row(1002, "Corte") :: Nil)
+          spark.sqlContext.createDataFrame(rdd, schema)
+        }
+        val (plan1, _) = lineageCaptor.lineageOf(testData
+          .write
+          .mode(SaveMode.Append)
+          .options(options)
+          .format(sparkFormat)
+          .save(s"$index/$docType")
+        )
+
+        val (plan2, _) = lineageCaptor.lineageOf {
+          val df = spark
+            .read
+            .options(options)
+            .format(sparkFormat)
+            .load(s"$index/$docType")
+
+          df
+            .write
+            .options(options)
+            .mode(SaveMode.Overwrite)
+            .save(s"$index/$docType")
+        }
+
+        plan1.operations.write.append shouldBe true
+        plan1.operations.write.extra.get("destinationType") shouldBe Some("elasticsearch")
+        plan1.operations.write.outputSource shouldBe s"elasticsearch://$esNodes/$index/$docType"
+
+        plan2.operations.reads.get.head.inputSources.head shouldBe plan1.operations.write.outputSource
+        plan2.operations.reads.get.head.extra.get("sourceType") shouldBe Some("elasticsearch")
+        plan2.operations.write.append shouldBe false
+
+        embeddedElastic.stop()
+      })
+    })
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,11 @@
                 <artifactId>mongo-spark-connector_${scala.binary.version}</artifactId>
                 <version>2.4.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch-hadoop</artifactId>
+                <version>7.6.0</version>
+            </dependency>
 
             <!-- Json4s -->
 


### PR DESCRIPTION
* added elasticsearch support issue-#606

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication
Increased timeout for embedded ES to start

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication
Increased timeout for embedded ES to start
Added tagsToExclude to exclude unsupported ES connector in scala 2.12

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication
Increased timeout for embedded ES to start
Added tagsToExclude to exclude unsupported ES connector in scala 2.12
Moved property tag to top of pom

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication
Increased timeout for embedded ES to start
Added tagsToExclude to exclude unsupported ES connector in scala 2.12
Moved property tag to top of pom
Added license to new file

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication
Increased timeout for embedded ES to start
Following built in exclude tags for ES on 2.12

* added elasticsearch support issue-#606
Updated test to use ES 6.6 and add options config to eliminate code duplication
Increased timeout for embedded ES to start
Following built in exclude tags for ES on 2.12
Using SafeTypeMatchingExtractor for WriteCommandExtractor to prevent class not found exceptions in production

Co-authored-by: David Radford <david.radford@cloudreach.com>